### PR TITLE
Add support for different keyboard layouts

### DIFF
--- a/egui_keyboard/README.md
+++ b/egui_keyboard/README.md
@@ -15,5 +15,5 @@ implemented in Winit/Egui stack.
 
 ## Features
 
-* Simple QWERTY layout with upper case and lower case letters.
+* Simple QWERTY and COLEMAK layout with upper case and lower case letters.
 * Pasting text from clipboard.

--- a/egui_keyboard/src/layouts.rs
+++ b/egui_keyboard/src/layouts.rs
@@ -12,7 +12,7 @@ impl Default for KeyboardLayout {
 }
 
 impl KeyboardLayout {
-    pub(crate) fn get_layout(&self, uppercase: bool) -> Vec<Vec<Key>> {
+    pub(crate) fn get_keys(&self, uppercase: bool) -> Vec<Vec<Key>> {
         match (self,uppercase) {
             (KeyboardLayout::Qwerty, false) => { qwerty() }
             (KeyboardLayout::Qwerty, true) => { qwerty_upper() }

--- a/egui_keyboard/src/layouts.rs
+++ b/egui_keyboard/src/layouts.rs
@@ -13,11 +13,11 @@ impl Default for KeyboardLayout {
 
 impl KeyboardLayout {
     pub(crate) fn get_keys(&self, uppercase: bool) -> Vec<Vec<Key>> {
-        match (self,uppercase) {
-            (KeyboardLayout::Qwerty, false) => { qwerty() }
-            (KeyboardLayout::Qwerty, true) => { qwerty_upper() }
-            (KeyboardLayout::Colemak, false) => { colemak() }
-            (KeyboardLayout::Colemak, true) => { colemak_upper() }
+        match (self, uppercase) {
+            (KeyboardLayout::Qwerty, false) => qwerty(),
+            (KeyboardLayout::Qwerty, true) => qwerty_upper(),
+            (KeyboardLayout::Colemak, false) => colemak(),
+            (KeyboardLayout::Colemak, true) => colemak_upper(),
         }
     }
 }

--- a/egui_keyboard/src/layouts.rs
+++ b/egui_keyboard/src/layouts.rs
@@ -1,6 +1,28 @@
 use super::Key;
 
-pub fn qwerty() -> Vec<Vec<Key>> {
+pub enum KeyboardLayout {
+    Qwerty,
+    Colemak,
+}
+
+impl Default for KeyboardLayout {
+    fn default() -> Self {
+        Self::Qwerty
+    }
+}
+
+impl KeyboardLayout {
+    pub(crate) fn get_layout(&self, uppercase: bool) -> Vec<Vec<Key>> {
+        match (self,uppercase) {
+            (KeyboardLayout::Qwerty, false) => { qwerty() }
+            (KeyboardLayout::Qwerty, true) => { qwerty_upper() }
+            (KeyboardLayout::Colemak, false) => { colemak() }
+            (KeyboardLayout::Colemak, true) => { colemak_upper() }
+        }
+    }
+}
+
+pub(crate) fn qwerty() -> Vec<Vec<Key>> {
     vec![
         vec![
             Key::Text("1"),
@@ -56,7 +78,7 @@ pub fn qwerty() -> Vec<Vec<Key>> {
     ]
 }
 
-pub fn qwerty_upper() -> Vec<Vec<Key>> {
+pub(crate) fn qwerty_upper() -> Vec<Vec<Key>> {
     vec![
         vec![
             Key::Text("!"),
@@ -102,6 +124,118 @@ pub fn qwerty_upper() -> Vec<Vec<Key>> {
             Key::Text("V"),
             Key::Text("B"),
             Key::Text("N"),
+            Key::Text("M"),
+            Key::Text("<"),
+            Key::Text(">"),
+            Key::Text("?"),
+            Key::Backspace,
+        ],
+        vec![Key::Text(" ")],
+    ]
+}
+
+pub(crate) fn colemak() -> Vec<Vec<Key>> {
+    vec![
+        vec![
+            Key::Text("1"),
+            Key::Text("2"),
+            Key::Text("3"),
+            Key::Text("4"),
+            Key::Text("5"),
+            Key::Text("6"),
+            Key::Text("7"),
+            Key::Text("8"),
+            Key::Text("9"),
+            Key::Text("0"),
+        ],
+        vec![
+            Key::Text("q"),
+            Key::Text("w"),
+            Key::Text("f"),
+            Key::Text("p"),
+            Key::Text("g"),
+            Key::Text("j"),
+            Key::Text("l"),
+            Key::Text("u"),
+            Key::Text("y"),
+            Key::Text(";"),
+        ],
+        vec![
+            Key::Text("a"),
+            Key::Text("r"),
+            Key::Text("s"),
+            Key::Text("t"),
+            Key::Text("d"),
+            Key::Text("h"),
+            Key::Text("n"),
+            Key::Text("e"),
+            Key::Text("i"),
+            Key::Text("o"),
+        ],
+        vec![
+            Key::Upper,
+            Key::Text("z"),
+            Key::Text("x"),
+            Key::Text("c"),
+            Key::Text("v"),
+            Key::Text("b"),
+            Key::Text("k"),
+            Key::Text("m"),
+            Key::Text(","),
+            Key::Text("."),
+            Key::Text("/"),
+            Key::Backspace,
+        ],
+        vec![Key::Text(" ")],
+    ]
+}
+
+pub(crate) fn colemak_upper() -> Vec<Vec<Key>> {
+    vec![
+        vec![
+            Key::Text("!"),
+            Key::Text("@"),
+            Key::Text("#"),
+            Key::Text("$"),
+            Key::Text("%"),
+            Key::Text("^"),
+            Key::Text("&"),
+            Key::Text("*"),
+            Key::Text("("),
+            Key::Text(")"),
+        ],
+        vec![
+            Key::Text("Q"),
+            Key::Text("W"),
+            Key::Text("F"),
+            Key::Text("P"),
+            Key::Text("G"),
+            Key::Text("J"),
+            Key::Text("L"),
+            Key::Text("U"),
+            Key::Text("Y"),
+            Key::Text(";"),
+        ],
+        vec![
+            Key::Text("A"),
+            Key::Text("R"),
+            Key::Text("S"),
+            Key::Text("T"),
+            Key::Text("D"),
+            Key::Text("H"),
+            Key::Text("N"),
+            Key::Text("E"),
+            Key::Text("I"),
+            Key::Text("O"),
+        ],
+        vec![
+            Key::Upper,
+            Key::Text("Z"),
+            Key::Text("X"),
+            Key::Text("C"),
+            Key::Text("V"),
+            Key::Text("B"),
+            Key::Text("K"),
             Key::Text("M"),
             Key::Text("<"),
             Key::Text(">"),

--- a/egui_keyboard/src/lib.rs
+++ b/egui_keyboard/src/lib.rs
@@ -1,13 +1,14 @@
 #![doc = include_str!("../README.md")]
 
 mod clipboard;
-mod layouts;
+pub mod layouts;
 
 use egui::{
     vec2, Align2, Button, Context, Event, Frame, Id, Modifiers, Order, Rect, Ui, Vec2, WidgetText,
     Window,
 };
 use std::collections::VecDeque;
+use crate::layouts::KeyboardLayout;
 
 enum Key {
     Text(&'static str),
@@ -22,6 +23,7 @@ pub struct Keyboard {
     input_widget: Option<Id>,
     events: VecDeque<Event>,
     upper: bool,
+    keyboard_layout: KeyboardLayout,
 
     /// How much keyboard is needed. It's a number so we can implement this as some sort of
     /// hysteresis to avoid flickering.
@@ -44,6 +46,11 @@ impl Keyboard {
     /// created, otherwise the key presses will be ignored.
     pub fn pump_events(&mut self, ctx: &Context) {
         ctx.input_mut(|input| input.events.extend(std::mem::take(&mut self.events)));
+    }
+
+    pub fn layout(mut self, layout: KeyboardLayout) -> Self {
+        self.keyboard_layout = layout;
+        self
     }
 
     /// Area which is free from the keyboard. This is useful when you want to constrain a window to
@@ -93,13 +100,9 @@ impl Keyboard {
 
                     self.clipboard_key(ui);
 
-                    let layout = if self.upper {
-                        layouts::qwerty_upper()
-                    } else {
-                        layouts::qwerty()
-                    };
+                    let keys = self.keyboard_layout.get_layout( self.upper );
 
-                    for row in layout.iter() {
+                    for row in keys.iter() {
                         ui.columns(row.len(), |columns| {
                             for (n, key) in row.iter().enumerate() {
                                 let ui = &mut columns[n];

--- a/egui_keyboard/src/lib.rs
+++ b/egui_keyboard/src/lib.rs
@@ -100,7 +100,7 @@ impl Keyboard {
 
                     self.clipboard_key(ui);
 
-                    let keys = self.keyboard_layout.get_layout( self.upper );
+                    let keys = self.keyboard_layout.get_keys(self.upper);
 
                     for row in keys.iter() {
                         ui.columns(row.len(), |columns| {

--- a/egui_keyboard/src/lib.rs
+++ b/egui_keyboard/src/lib.rs
@@ -3,12 +3,12 @@
 mod clipboard;
 pub mod layouts;
 
+use crate::layouts::KeyboardLayout;
 use egui::{
     vec2, Align2, Button, Context, Event, Frame, Id, Modifiers, Order, Rect, Ui, Vec2, WidgetText,
     Window,
 };
 use std::collections::VecDeque;
-use crate::layouts::KeyboardLayout;
 
 enum Key {
     Text(&'static str),


### PR DESCRIPTION
Hi, love the repository.

As a challenge and feature for myself I added colemak support.

It can be set the following way:
```rust
Keyboard::default().layout(KeyboardLayout::Colemak)
```

I kept Qwerty as default value.

Happy to update my merge request with feedback!